### PR TITLE
Improve build guideline by providing clear commands and patch file

### DIFF
--- a/osrm/references/files/enable-xcode-project.diff
+++ b/osrm/references/files/enable-xcode-project.diff
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e1767b961..8d85c197e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -170,11 +170,11 @@ add_executable(osrm-datastore src/tools/store.cpp $<TARGET_OBJECTS:MICROTAR> $<T
+ add_library(osrm src/osrm/osrm.cpp $<TARGET_OBJECTS:ENGINE> $<TARGET_OBJECTS:STORAGE> $<TARGET_OBJECTS:MICROTAR> $<TARGET_OBJECTS:UTIL>)
+ add_library(osrm_contract src/osrm/contractor.cpp $<TARGET_OBJECTS:CONTRACTOR> $<TARGET_OBJECTS:UTIL>)
+ add_library(osrm_extract src/osrm/extractor.cpp $<TARGET_OBJECTS:EXTRACTOR> $<TARGET_OBJECTS:MICROTAR> $<TARGET_OBJECTS:UTIL>)
+-add_library(osrm_guidance $<TARGET_OBJECTS:GUIDANCE> $<TARGET_OBJECTS:UTIL>)
++add_library(osrm_guidance $<TARGET_OBJECTS:GUIDANCE> $<TARGET_OBJECTS:UTIL> src/dummy.cpp)
+ add_library(osrm_partition src/osrm/partitioner.cpp $<TARGET_OBJECTS:PARTITIONER> $<TARGET_OBJECTS:MICROTAR> $<TARGET_OBJECTS:UTIL>)
+ add_library(osrm_customize src/osrm/customizer.cpp $<TARGET_OBJECTS:CUSTOMIZER> $<TARGET_OBJECTS:MICROTAR> $<TARGET_OBJECTS:UTIL>)
+-add_library(osrm_update $<TARGET_OBJECTS:UPDATER> $<TARGET_OBJECTS:MICROTAR> $<TARGET_OBJECTS:UTIL>)
+-add_library(osrm_store $<TARGET_OBJECTS:STORAGE> $<TARGET_OBJECTS:MICROTAR> $<TARGET_OBJECTS:UTIL>)
++add_library(osrm_update $<TARGET_OBJECTS:UPDATER> $<TARGET_OBJECTS:MICROTAR> $<TARGET_OBJECTS:UTIL> src/updater/csv_source.cpp src/updater/updater.cpp)
++add_library(osrm_store $<TARGET_OBJECTS:STORAGE> $<TARGET_OBJECTS:MICROTAR> $<TARGET_OBJECTS:UTIL> src/storage/io_config.cpp src/storage/storage.cpp)
+ 
+ if(ENABLE_GOLD_LINKER)
+     execute_process(COMMAND ${CMAKE_C_COMPILER} -fuse-ld=gold -Wl,--version ERROR_QUIET OUTPUT_VARIABLE LD_VERSION)


### PR DESCRIPTION
## Issue
Current build guidelines for generating Xcode project on OSX has some errors:
1. The working directory for applying patch should be at root directory, instead of src dir.
2. The patch seems have some special characters, which means directly copying the content won't work.
3. During build, the working directory is already the build folder, so don't need to use `build/OSRM.xcodeproj` to find Xcode project.

## Task List
- [x] Correct the errors for the commands in md.
- [x] Publish patch directly as a file.
- [x] Tune some wording to make the guideline clearer.